### PR TITLE
Simplest React+Babel+Webpack build as a Maven build step

### DIFF
--- a/acctMngr/pom.xml
+++ b/acctMngr/pom.xml
@@ -247,6 +247,50 @@
 					</webApp>
 				</configuration>
 			</plugin>
+			<plugin>
+		        <groupId>com.github.eirslett</groupId>
+		        <artifactId>frontend-maven-plugin</artifactId>
+		        <!-- Use the latest released version:
+		        https://repo1.maven.org/maven2/com/github/eirslett/frontend-maven-plugin/ -->
+		        <version>1.6</version>
+		        <configuration>
+                    <installDirectory>target</installDirectory>
+                    <workingDirectory>src/main/frontend</workingDirectory>
+				</configuration>
+		        <executions>
+		        
+                    <execution>
+                        <id>install node and yarn</id>
+                        <goals>
+                            <goal>install-node-and-yarn</goal>
+                        </goals>
+                        <configuration>
+                            <nodeVersion>v9.8.0</nodeVersion>
+                            <yarnVersion>v1.5.1</yarnVersion>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>yarn install</id>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>install</arguments>
+                        </configuration>
+                    </execution>
+                    
+                    <execution>
+					    <id>webpack build</id>
+					    <goals>
+					        <goal>webpack</goal>
+					    </goals>
+					
+					    <!-- optional: the default phase is "generate-resources" -->
+					    <phase>generate-resources</phase>
+					</execution>
+				</executions>
+		    </plugin>
 		</plugins>
 	</build>
 </project>

--- a/acctMngr/src/main/frontend/.babelrc
+++ b/acctMngr/src/main/frontend/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["react", "env"]
+}

--- a/acctMngr/src/main/frontend/.gitignore
+++ b/acctMngr/src/main/frontend/.gitignore
@@ -1,0 +1,4 @@
+dist/
+node_modules/
+yarn-error.log
+yarn.lock

--- a/acctMngr/src/main/frontend/index.html
+++ b/acctMngr/src/main/frontend/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <head>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="dist/bundle.js"></script>
+  </body>
+</html>

--- a/acctMngr/src/main/frontend/index.js
+++ b/acctMngr/src/main/frontend/index.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+ReactDOM.render(
+  <h1>Hello, world!</h1>,
+  document.getElementById('root')
+);
+
+

--- a/acctMngr/src/main/frontend/package.json
+++ b/acctMngr/src/main/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-in-spring",
   "version": "1.0.0",
-  "description": "Getting familiar with the native yarn install process",
+  "description": "",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {

--- a/acctMngr/src/main/frontend/package.json
+++ b/acctMngr/src/main/frontend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "react-in-spring",
+  "version": "1.0.0",
+  "description": "Getting familiar with the native yarn install process",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "babel-core": "^6.26.0",
+    "babel-loader": "^7.1.4",
+    "babel-preset-env": "^1.6.1",
+    "babel-preset-react": "^6.24.1",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
+    "webpack": "^4.1.1",
+    "webpack-cli": "^2.0.12"
+  }
+}

--- a/acctMngr/src/main/frontend/webpack.config.js
+++ b/acctMngr/src/main/frontend/webpack.config.js
@@ -1,10 +1,3 @@
-//module: {
-//  rules: [
-//    { test: /\.js$/, exclude: /node_modules/, loader: "babel-loader" }
-//  ]
-//}
-
-
 module.exports = {
   entry: './index.js',
   output: {

--- a/acctMngr/src/main/frontend/webpack.config.js
+++ b/acctMngr/src/main/frontend/webpack.config.js
@@ -1,0 +1,22 @@
+//module: {
+//  rules: [
+//    { test: /\.js$/, exclude: /node_modules/, loader: "babel-loader" }
+//  ]
+//}
+
+
+module.exports = {
+  entry: './index.js',
+  output: {
+    filename: 'bundle.js'
+  },
+  module: {
+    rules: [
+      {
+      test: /\.js$/,
+      exclude: /(node_modules|bower_components)/,
+      loader: 'babel-loader'
+      }
+    ]
+  }
+};


### PR DESCRIPTION
Using [frontend-maven-plugin](https://github.com/eirslett/frontend-maven-plugin)

Plugin pulls `npm` and `yarn` for us (their versions are hardcoded in `pom.xml`).
Yarn (Node Package Manager) installs Node packages specified in `src/main/frontend/package.json`.
Webpack (Bundles and minifies Javascript) invokes Babel (JSX to old-browser-compliant Javascript compiler) configured respectively in `src/main/frontend/webpack.config.js` and `src/main/frontend/.babelrc` on `/src/main/frontend/index.js` (the minimal React app) and outputs the compiled Javascript to `src/main/frontend/dist/bundle.js`. To verify this all worked, open `src/main/frontend/index.html` with a browser - you should see "Hello, world!".

What's not implemented is the actual integration with Spring. Best way to go seems to be
to make backend (Spring) expose REST resources and let frontend (React) query those resources.

React + Spring integration idea taken from [this Reddit thread](https://www.reddit.com/r/reactjs/comments/5u7q5s/new_to_reactjsusing_with_javaspring_backend/ddsg4ly/)